### PR TITLE
Reduce max input characters in MainPage Entry to 15

### DIFF
--- a/Roachagram.MobileUI/MainPage.xaml.cs
+++ b/Roachagram.MobileUI/MainPage.xaml.cs
@@ -9,7 +9,7 @@ namespace Roachagram.MobileUI
     public partial class MainPage : ContentPage
     {
         // Maximum number of characters allowed in the input Entry.
-        const int maxInputCharacters = 25;
+        const int maxInputCharacters = 15;
         private const int TEXT_EASE_IN_SECONDS = 2000;
         private readonly IRoachagramAPIService? _roachagramAPIService;
         private readonly IRemoteTelemetryService? _remoteTelemetryService;


### PR DESCRIPTION
The `maxInputCharacters` constant in the `MainPage` class was updated from 25 to 15. This change enforces stricter input constraints for the Entry field, potentially aligning with updated application requirements or improving user experience.